### PR TITLE
Add troubleshooting in readme for cordova (or ionic)

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,6 +266,12 @@ this.embedService
   });
 ```
 
+## Troubleshooting
+In Cordoba (or Ionic) mobile app, on iOS if you have a  blank frame instead of video iframe then you need to add ```allow-navigation``` configuration in ```config.xml```, for instance for YouTube: 
+```
+<allow-navigation href="https://*youtube.com/*"/>
+```
+
 ## License
 
 MIT


### PR DESCRIPTION
In Cordova (or Ionci) app, on iOS it requires config https://stackoverflow.com/questions/36758464/iframe-youtube-video-in-cordova-app-on-ios-not-working-any-more